### PR TITLE
#6 CRS message adapted

### DIFF
--- a/autocorrectborders.py
+++ b/autocorrectborders.py
@@ -885,7 +885,7 @@ class AutocorrectBordersProcessingAlgorithm(QgsProcessingAlgorithm):
         if reference.sourceCrs().authid() != self.CRS:
             raise QgsProcessingException(
                 "Thematic layer and ReferenceLayer are in a different CRS. "
-                "Please provide them in the same CRS (EPSG:31370 or EPSG:3812)"
+                "Please provide them in the same CRS, with units in meter (f.e. For Belgium in EPSG:31370 or EPSG:3812)"
             )
         outputs[self.INPUT_REFERENCE + "_id"] = processing.run(
             "native:fieldcalculator",


### PR DESCRIPTION
changed the error message on CRS, that all CRS (with units in meter) are allowed. the only requirement is a CRS (units:meter) and that referencelayer and thematic layer have the same CRS